### PR TITLE
HHH-11067 | Updated to hibernate-core 5.2.2.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<version.com.h2database>1.3.176</version.com.h2database>
 		<version.junit>4.12</version.junit>
-		<version.org.hibernate>5.2.1.Final</version.org.hibernate>
+		<version.org.hibernate>5.2.2.Final</version.org.hibernate>
 		<version.org.slf4j>1.7.2</version.org.slf4j>
 		<version.hamcrest>1.3</version.hamcrest>
 	</properties>
@@ -60,6 +60,26 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>src-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <!-- use copy-dependencies instead if you don't want to explode the sources -->
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <classifier>sources</classifier>
+              <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+              <outputDirectory>${project.build.directory}/sources</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
- HHH-11067 | Updated to hibernate-core 5.2.2.Final.
- HHH-11067 | Now using maven-dependency-plugin to download source jars.
